### PR TITLE
 bstract method for retriving time stamp for sorting 

### DIFF
--- a/xcube_gen_rbins/iproc.py
+++ b/xcube_gen_rbins/iproc.py
@@ -47,6 +47,9 @@ class RbinsSeviriHighrocSceneInputProcessor(XYInputProcessor):
                                 xy_crs=CRS_WKT_EPSG_4326,
                                 xy_gcp_step=1)
 
+    def get_time_for_sorting(self, dataset: xr.Dataset) -> Optional[str]:
+        return DefaultInputProcessor().get_time_for_sorting(dataset)
+
     def get_time_range(self, dataset: xr.Dataset) -> Tuple[float, float]:
         return DefaultInputProcessor().get_time_range(dataset)
 
@@ -67,6 +70,8 @@ class RbinsSeviriHighrocDailyInputProcessor(XYInputProcessor):
         return ReprojectionInfo(xy_var_names=('longitude', 'latitude'),
                                 xy_crs=CRS_WKT_EPSG_4326,
                                 xy_gcp_step=1)
+    def get_time_for_sorting(self, dataset: xr.Dataset) -> Optional[str]:
+        return DefaultInputProcessor().get_time_for_sorting(dataset)
 
     def get_time_range(self, dataset: xr.Dataset) -> Optional[Tuple[float, float]]:
         return None

--- a/xcube_gen_rbins/iproc.py
+++ b/xcube_gen_rbins/iproc.py
@@ -67,9 +67,6 @@ class RbinsSeviriHighrocDailyInputProcessor(XYInputProcessor):
                                 xy_crs=CRS_WKT_EPSG_4326,
                                 xy_gcp_step=1)
 
-    def get_time_for_sorting(self, dataset: xr.Dataset) -> Optional[str]:
-        return DefaultInputProcessor().get_time_for_sorting(dataset)
-
     def get_time_range(self, dataset: xr.Dataset) -> Optional[Tuple[float, float]]:
         return None
 

--- a/xcube_gen_rbins/iproc.py
+++ b/xcube_gen_rbins/iproc.py
@@ -24,7 +24,6 @@ from typing import Optional, Tuple
 
 import numpy as np
 import xarray as xr
-
 from xcube.constants import CRS_WKT_EPSG_4326
 from xcube.core.gen.iproc import DefaultInputProcessor
 from xcube.core.gen.iproc import ReprojectionInfo, XYInputProcessor
@@ -47,9 +46,6 @@ class RbinsSeviriHighrocSceneInputProcessor(XYInputProcessor):
                                 xy_crs=CRS_WKT_EPSG_4326,
                                 xy_gcp_step=1)
 
-    def get_time_for_sorting(self, dataset: xr.Dataset) -> Optional[str]:
-        return DefaultInputProcessor().get_time_for_sorting(dataset)
-
     def get_time_range(self, dataset: xr.Dataset) -> Tuple[float, float]:
         return DefaultInputProcessor().get_time_range(dataset)
 
@@ -70,6 +66,7 @@ class RbinsSeviriHighrocDailyInputProcessor(XYInputProcessor):
         return ReprojectionInfo(xy_var_names=('longitude', 'latitude'),
                                 xy_crs=CRS_WKT_EPSG_4326,
                                 xy_gcp_step=1)
+
     def get_time_for_sorting(self, dataset: xr.Dataset) -> Optional[str]:
         return DefaultInputProcessor().get_time_for_sorting(dataset)
 


### PR DESCRIPTION
This PR adds an abstract method for retrieving the time stamp for sorting input paths in xcube gen.
This PR needs to be reviewed together with dcs4cop/xcube#223, because it is based on the changes in that pull request.